### PR TITLE
Set Contempt to 0 so engines produce a fair evaluation

### DIFF
--- a/src/TcecEvaluationBot.ConsoleUI/Services/UciEnginePositionEvaluator.cs
+++ b/src/TcecEvaluationBot.ConsoleUI/Services/UciEnginePositionEvaluator.cs
@@ -48,6 +48,7 @@
             {
                 process.StandardInput.WriteLine($"setoption name SyzygyPath value {this.options.SyzygyPath}");
             }
+            process.StandardInput.WriteLine($"setoption name Contempt value 0");
 
             process.StandardInput.WriteLine($"position fen {fenPosition}");
             process.StandardInput.WriteLine($"go movetime {moveTime}");


### PR DESCRIPTION
Because some engines haven't set their Contempt option to 0 by default, these engines produce a different evaluation value for the same position depending on whether white or black is to move. This explicitly sets the Contempt option to 0.