### PR TITLE
Adjust scores from chessdbcn such that they are always from white's perspective.

### DIFF
--- a/src/TcecEvaluationBot.ConsoleUI/Services/ChessDbcnScoreProvider.cs
+++ b/src/TcecEvaluationBot.ConsoleUI/Services/ChessDbcnScoreProvider.cs
@@ -1,5 +1,6 @@
 ﻿namespace TcecEvaluationBot.ConsoleUI.Services
 {
+    using ChessDotNet;
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
@@ -64,6 +65,8 @@
         {
             Dictionary<string, ChessDbcnScore> scores = new Dictionary<string, ChessDbcnScore>();
 
+            var sideToMove = fen.Contains(" b ") ? Player.Black : Player.White;
+
             string[] byMoveStrs = responseStr.Split('|');
             foreach (var byMoveStr in byMoveStrs)
             {
@@ -90,7 +93,7 @@
                     {
                         // AlgebraicToSan produces '\0' bytes. TODO: fix?
                         var san = MoveConverter.AlgebraicToSan(fen, moveStr).Replace("\0", string.Empty);
-                        scores.Add(san, new ChessDbcnScore(scoreStr));
+                        scores.Add(san, new ChessDbcnScore(scoreStr, sideToMove));
                     }
                     catch
                     {

--- a/src/TcecEvaluationBot.ConsoleUI/Services/Models/ChessDbcnScore.cs
+++ b/src/TcecEvaluationBot.ConsoleUI/Services/Models/ChessDbcnScore.cs
@@ -1,5 +1,6 @@
 ﻿namespace TcecEvaluationBot.ConsoleUI.Services.Models
 {
+    using ChessDotNet;
     using System;
     using System.Globalization;
 
@@ -9,27 +10,27 @@
         private static readonly int CursedDtz0 = 20000;
         private static readonly int Dtz0 = 30000;
 
-        public ChessDbcnScore(int v)
+        public ChessDbcnScore(int v, Player sideToMove)
         {
-            this.Value = v;
+            this.Value = GetValueForPlayer(v, sideToMove);
             this.Perf = 0;
         }
 
-        public ChessDbcnScore(string str)
+        public ChessDbcnScore(string str, Player sideToMove)
         {
-            this.Value = ValueFromString(str);
+            this.Value = GetValueForPlayer(ValueFromString(str), sideToMove);
             this.Perf = str == null ? double.NaN : WinPctFromEval(this.Value);
         }
 
-        public ChessDbcnScore(int v, double pct)
+        public ChessDbcnScore(int v, double pct, Player sideToMove)
         {
-            this.Value = v;
+            this.Value = GetValueForPlayer(v, sideToMove);
             this.Perf = pct;
         }
 
-        public ChessDbcnScore(string value, string winpct)
+        public ChessDbcnScore(string value, string winpct, Player sideToMove)
         {
-            this.Value = ValueFromString(value);
+            this.Value = GetValueForPlayer(ValueFromString(value), sideToMove);
             this.Perf = WinPctFromString(winpct);
         }
 
@@ -120,6 +121,11 @@
             }
 
             return 1.0 / (1.0 + Math.Exp(-eval / 90.0));
+        }
+
+        private static int GetValueForPlayer(int value, Player sideToMove)
+        {
+            return sideToMove == Player.White ? value : -value;
         }
     }
 }


### PR DESCRIPTION
I assumed cdb reports scores from white's perspective, but actually it seems it reports them from side to move perspective... This fixes the displayed values and sorting.